### PR TITLE
allow semantic release to comment PRs

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   release:
@@ -33,7 +34,7 @@ jobs:
           node-version: latest
 
       - name: Install additional plugins
-        run: npm install @semantic-release/git @semantic-release/changelog -D
+        run: npm install @semantic-release/changelog -D
 
       - name: Generate release
         env:


### PR DESCRIPTION
Semantic release tries to comment in pull requests
that they were released in one specific version.
